### PR TITLE
Disconnect method

### DIFF
--- a/lib/gmail.rb
+++ b/lib/gmail.rb
@@ -105,6 +105,12 @@ class Gmail
       @logged_in = false if res.name == 'OK'
     end
   end
+  
+  # Shutdown socket and disconnect
+  def disconnect
+    logout if logged_in?
+    @imap.disconnect unless @imap.disconnected?
+  end  
 
   def in_mailbox(mailbox, &block)
     if block_given?


### PR DESCRIPTION
I was running a process that would login to gmail parse messages, logout and repeat. Unfortunately the number of open TCP sockets for this process kept increasing with time and at some point (hours later) my process crashed with a Too many open connections error.

Added a disconnect method which basically calls @imap.disconnect. Let me know if you need me to tweak it. Thanks for the library. 
