### PR TITLE
Added two methods for labels and fixed a bug

### DIFF
--- a/lib/gmail.rb
+++ b/lib/gmail.rb
@@ -56,8 +56,11 @@ class Gmail
 
   # List the available labels
   def labels
-    mailbox_list.inject([]) { |labels,label|
-      label[:name].each_line { |l| labels << l }; labels }
+    mailbox_list.inject([]) do |labels,label|
+      labels << label[:name] unless label.attr.include?(:Noselect)
+
+      labels
+    end
   end
 
   # gmail.label(name)


### PR DESCRIPTION
- Added two methods: `destroy_label` and `rename_label`
- Fixed a bug where the `labels` method was reporting labels that weren't actually in gmail. This only comes up when there are missing filters in the hierarchy.
