### PR TITLE
Allow searching gmail with X-GM-RAW

### DIFF
--- a/lib/gmail/mailbox.rb
+++ b/lib/gmail/mailbox.rb
@@ -51,6 +51,12 @@ class Gmail
         search.concat ['FROM', opts[:from]] if opts[:from]
         search.concat ['TO', opts[:to]] if opts[:to]
         search.concat ['SUBJECT', opts[:subject]] if opts[:subject]
+
+        # Gmail offers us to search the same way we do on the web interface
+        # https://developers.google.com/gmail/imap_extensions
+        # example: gmail.emails(gm: 'has:attachment in:unread "who is john galt"')
+        # 
+        search.concat ['X-GM-RAW', opts[:gm]] if opts[:gm]
       end
 
       # puts "Gathering #{(aliases[key] || key).inspect} messages for mailbox '#{name}'..."


### PR DESCRIPTION
Gmail has a Search extension that allows us to run the same queries of the web interface through imap. 
I feel this is a great improvement to the gem, yet not sure how you people are testing and documenting it.

Please let me know how to have this change approved :)
