### PR TITLE
Fixed dependency list on README: mail instead of tmail

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -144,7 +144,7 @@ Creating emails now uses the amazing [Mail](http://rubygems.org/gems/mail) rubyg
 * ruby
 * net/smtp
 * net/imap
-* tmail
+* mail
 * shared-mime-info rubygem (for MIME-detection when attaching files)
 
 ## Install


### PR DESCRIPTION
It has almost put me off when I read 'tmail', as it has some problems on Ruby 2.1.x
