### PR TITLE
resolved #89 - fixed IMAP date format

### DIFF
--- a/lib/gmail/mailbox.rb
+++ b/lib/gmail/mailbox.rb
@@ -2,7 +2,7 @@ require 'date'
 require 'time'
 class Object
   def to_imap_date
-    Date.parse(to_s).strftime("%d-%B-%Y")
+    Date.parse(to_s).strftime("%d-%b-%Y")
   end
 end
 


### PR DESCRIPTION
https://github.com/dcparker/ruby-gmail/issues/89

Yesterday I started getting `Net::IMAP::BadResponseError: Could not parse command` when used **before** and **after** params for inbox.

Date format in IMAP spec
https://tools.ietf.org/html/rfc3501 page 83

```
date-month      = "Jan" / "Feb" / "Mar" / "Apr" / "May" / "Jun" /
                  "Jul" / "Aug" / "Sep" / "Oct" / "Nov" / "Dec"
```
