### PR TITLE
Update smtp_tls.rb

### DIFF
--- a/lib/smtp_tls.rb
+++ b/lib/smtp_tls.rb
@@ -1,5 +1,6 @@
 require "openssl"
 require "net/smtp"
+require "timeout"
 
 Net::SMTP.class_eval do
   
@@ -36,7 +37,7 @@ Net::SMTP.class_eval do
       check_auth_args(user, secret) if user or secret
     end
 
-    sock = timeout(@open_timeout) { TCPSocket.open(@address, @port) }
+    sock = Timeout.timeout(@open_timeout) { TCPSocket.open(@address, @port) }
     @socket = Net::InternetMessageIO.new(sock)
     @socket.read_timeout = 60 #@read_timeout
     @socket.debug_output = STDERR #@debug_output


### PR DESCRIPTION
fix below error.

/usr/local/lib/ruby/gems/2.4.0/gems/ruby-gmail-0.3.1/lib/smtp_tls.rb:39:in `do_tls_start': Object#timeout is deprecated, use Timeout.timeout instead.